### PR TITLE
PGPolicy implementation POC

### DIFF
--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -1,0 +1,133 @@
+# pylint: disable=unused-argument,invalid-name,line-too-long
+from __future__ import annotations
+
+from typing import List
+
+from parse import parse
+from sqlalchemy import text as sql_text
+
+from alembic_utils.exceptions import SQLParseFailure
+from alembic_utils.replaceable_entity import ReplaceableEntity
+
+
+class PGPolicy(ReplaceableEntity):
+    """A PostgreSQL Function compatible with `alembic revision --autogenerate`
+
+    **Parameters:**
+
+    * **schema** - *str*: A SQL schema name
+    * **signature** - *str*: A SQL policy name and tablename, separated by "."
+    * **definition** - *str*:  The definition of the policy, incl. permissive, for, to, using, with check
+
+    """
+
+    is_replaceable = False
+
+    @classmethod
+    def from_sql(cls, sql: str) -> PGPolicy:
+        """Create an instance instance from a SQL string"""
+
+        template = "create policy{signature}on{schema}.{tablename}{:s}{definition}"
+        result = parse(template, sql.strip(), case_sensitive=False)
+
+        if result is not None:
+            return cls(
+                schema=result["schema"],
+                signature=f'{result["signature"]}.{result["tablename"]}',
+                definition=result["definition"],
+            )
+        raise SQLParseFailure(f'Failed to parse SQL into PGPolicy """{sql}"""')
+
+    @property
+    def policyname(self):
+        return self.signature.split(".")[0]
+
+    @property
+    def tablename(self):
+        return self.signature.split(".")[1]
+
+    def to_sql_statement_create(self) -> str:
+        """ Generates a SQL "create poicy" statement for PGPolicy """
+
+        return sql_text(
+            f"CREATE POLICY {self.policyname} on {self.schema}.{self.tablename} {self.definition}"
+        )
+
+    def to_sql_statement_drop(self) -> str:
+        """Generates a SQL "drop policy" statement for PGPolicy"""
+
+        return sql_text(f"DROP POLICY {self.policyname} on {self.schema}.{self.tablename}")
+
+    def to_sql_statement_create_or_replace(self) -> str:
+        """Not implemented, postgres policies do not support replace."""
+        raise NotImplementedError()
+
+    @classmethod
+    def from_database(cls, connection, schema) -> List[PGPolicy]:
+        """Get a list of all policies defined in the db"""
+        sql = sql_text(
+            f"""
+        select
+            schemaname,
+            tablename,
+            policyname,
+            permissive,
+            roles,
+            cmd,
+            qual,
+            with_check
+        from
+            pg_policies
+        where
+            schemaname = '{schema}'
+        """
+        )
+        rows = connection.execute(sql).fetchall()
+
+        def get_definition(permissive, cmd, roles, qual, with_check):
+            definition = ""
+            if permissive is not None:
+                definition += f"as {permissive}"
+            if cmd is not None:
+                definition += f"for {cmd}"
+            if roles is not None:
+                definition += f"to {','.join(roles)}"
+            if qual is not None:
+                definition += f"using {qual}"
+            if with_check is not None:
+                definition += f"with check {with_check}"
+
+        db_policies = [PGPolicy(x[0], f"{x[2]}.{x[1]}", get_definition(*x[3:])) for x in rows]
+
+        for policy in db_policies:
+            assert policy is not None
+
+        return db_policies
+
+    def get_compare_identity_query(self):
+        """Only called in simulation. alembic_util schema will only have 1 record"""
+        return f"""
+        select
+            tablename,
+            policyname
+        from
+            pg_policies
+        where
+            schemaname = '{self.schema}'
+        """
+
+    def get_compare_definition_query(self):
+        """Only called in simulation. alembic_util schema will only have 1 record"""
+
+        return f"""
+        select
+            permissive,
+            roles,
+            cmd,
+            qual,
+            with_check
+        from
+            pg_policies
+        where
+            schemaname = '{self.schema}'
+        """

--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -93,9 +93,9 @@ class PGPolicy(ReplaceableEntity):
             if roles is not None:
                 definition += f"to {', '.join(roles)} "
             if qual is not None:
-                definition += f"using {qual} "
+                definition += f"using ({qual}) "
             if with_check is not None:
-                definition += f"with check {with_check} "
+                definition += f"with check ({with_check}) "
             return normalize_whitespace(definition)
 
         db_policies = [PGPolicy(x[0], f"{x[2]}.{x[1]}", get_definition(*x[3:])) for x in rows]

--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -85,6 +85,7 @@ class PGPolicy(ReplaceableEntity):
         rows = connection.execute(sql).fetchall()
 
         def get_definition(permissive, roles, cmd, qual, with_check):
+
             definition = ""
             if permissive is not None:
                 definition += f"as {permissive} "
@@ -93,9 +94,13 @@ class PGPolicy(ReplaceableEntity):
             if roles is not None:
                 definition += f"to {', '.join(roles)} "
             if qual is not None:
-                definition += f"using ({qual}) "
+                if qual[0] != "(":
+                    qual = f"({qual})"
+                definition += f"using {qual} "
             if with_check is not None:
-                definition += f"with check ({with_check}) "
+                if with_check[0] != "(":
+                    with_check = f"({with_check})"
+                definition += f"with check {with_check} "
             return normalize_whitespace(definition)
 
         db_policies = [PGPolicy(x[0], f"{x[2]}.{x[1]}", get_definition(*x[3:])) for x in rows]
@@ -128,6 +133,8 @@ class PGPolicy(ReplaceableEntity):
 
         return f"""
         select
+            tablename,
+            policyname,
             permissive,
             roles,
             cmd,

--- a/src/test/test_pg_policy.py
+++ b/src/test/test_pg_policy.py
@@ -1,0 +1,155 @@
+from alembic_utils.pg_policy import PGPolicy
+from alembic_utils.replaceable_entity import register_entities
+from alembic_utils.testbase import TEST_VERSIONS_ROOT, run_alembic_command
+import functools
+
+# The role alem_user must be defined
+
+TEST_POLICY = PGPolicy(
+    schema="DEV",
+    signature="postgres_all.user",
+    definition="""
+        AS permissive
+        FOR ALL
+        TO alem_user
+        USING ("id" = 1)
+        WITH CHECK ("id" = 1);
+        """,
+)
+
+
+def with_table(func):
+    @functools.wraps(func)
+    def wrapper(engine) -> None:
+        # A postgres policy is applied to a table
+        engine.execute('CREATE TABLE "DEV".user (id integer)')
+
+        func(engine)
+
+    return wrapper
+
+
+@with_table
+def test_create_revision(engine) -> None:
+    register_entities([TEST_POLICY])
+
+    run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "1", "message": "create"},
+    )
+
+    migration_create_path = TEST_VERSIONS_ROOT / "1_create.py"
+
+    with migration_create_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.create_entity" in migration_contents
+    assert "op.drop_entity" in migration_contents
+    assert "op.replace_entity" not in migration_contents
+    assert "from alembic_utils.pg_policy import PGPolicy" in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+@with_table
+def test_update_revision(engine) -> None:
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    # Update definition of TEST_POLICY
+    UPDATED_TEST_POLICY = PGPolicy(
+        TEST_POLICY.schema,
+        TEST_POLICY.signature,
+        r"""AS restrictive
+        FOR UPDATE
+        TO alem_user
+        USING ("id" = 2)
+        WITH CHECK ("id" = 2);""",
+    )
+
+    register_entities([UPDATED_TEST_POLICY])
+
+    # Autogenerate a new migration
+    # It should detect the change we made and produce a "replace_function" statement
+    run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "2", "message": "replace"},
+    )
+
+    migration_replace_path = TEST_VERSIONS_ROOT / "2_replace.py"
+
+    with migration_replace_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.replace_entity" in migration_contents
+    assert "op.create_entity" not in migration_contents
+    assert "op.drop_entity" not in migration_contents
+    assert "from alembic_utils.pg_policy import PGPolicy" in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+@with_table
+def test_noop_revision(engine) -> None:
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    register_entities([TEST_POLICY])
+
+    output = run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "3", "message": "do_nothing"},
+    )
+    migration_do_nothing_path = TEST_VERSIONS_ROOT / "3_do_nothing.py"
+
+    with migration_do_nothing_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.create_entity" not in migration_contents
+    assert "op.drop_entity" not in migration_contents
+    assert "op.replace_entity" not in migration_contents
+    assert "from alembic_utils" not in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+@with_table
+def test_drop_revision(engine) -> None:
+
+    # Register no functions locally
+    register_entities([], schemas=["DEV"])
+
+    # Manually create a SQL function
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "1", "message": "drop"},
+    )
+
+    migration_create_path = TEST_VERSIONS_ROOT / "1_drop.py"
+
+    with migration_create_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.drop_entity" in migration_contents
+    assert "op.create_entity" in migration_contents
+    assert "from alembic_utils" in migration_contents
+    assert migration_contents.index("op.drop_entity") < migration_contents.index("op.create_entity")
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})


### PR DESCRIPTION
Hi @olirice, this is a sketch implementation for a `PGPolicy`. Definitely don't think it is mergeable yet, but I'd be interested to hear your thoughts?

Postgres policies have the following differences to views/mat views/functions, and I've had to construct workarounds accordingly:

1. There is no "CREATE OR REPLACE" operation, you need to "DROP POLICY ....; CREATE POLICY ...;" instead. To get around this, I've add an `is_replaceable` class attribute and a switch behaviour in the replace op.

2. Policies are defined for a unique *table*, rather than a unique *schema*. Given the importance of `schema` for things like the `alembic_utils` schema, I've left that alone and instead bundled together the `tablename` and `policyname` into one as the `signature`, since this combination is unique per schema. However, this is super hacky - the solution is to do `signature = f"{policyname}.{tablename}"` and `policyname = signature.split()[0]`, etc, which isn't going to work in general, for example if a table name contains a full stop.

3. When a policy is created, it needs to have all the tables it references available, including any of the fields referenced in `using` or `with_check`. As a workaround for simulation, I do `create table alembic_utils.XXX (like schema.XXX including all);`, but this would fail in the case where the policy references another table via a join (or I think so, to be fair did not test this).

Interestingly, these three points are true for triggers, which I am planning to implement next.

Look forward to hearing your thoughts!