### PR TITLE
Implement PGPolicy

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,9 +55,32 @@ from alembic_utils.pg_trigger import PGTrigger
 trigger = PGTrigger(
     schema="public",
     signature="lower_account_email",
+    on_entity="public.account",
     definition="""
         BEFORE INSERT ON public.account
         FOR EACH ROW EXECUTE FUNCTION public.downcase_email()
+    """,
+)
+```
+
+
+::: alembic_utils.pg_policy.PGPolicy
+    :docstring:
+    :members: from_sql from_path
+
+
+```python
+from alembic_utils.pg_policy import PGPolicy
+
+policy = PGPolicy(
+    schema="public",
+    signature="allow_read",
+    on_entity="public.account",
+    definition="""
+        AS PERMISSIVE
+        FOR SELECT
+        TO api_user
+        USING (id = current_setting('api_current_user', true)::int)
     """,
 )
 ```

--- a/src/alembic_utils/on_entity_mixin.py
+++ b/src/alembic_utils/on_entity_mixin.py
@@ -1,0 +1,22 @@
+from alembic_utils.statement import coerce_to_unquoted
+
+
+class OnEntityMixin:
+    """Mixin to ReplaceableEntity providing setup for entity types requiring an "ON" clause"""
+
+    def __init__(self, schema: str, signature: str, definition: str, on_entity: str = None):
+        super().__init__(schema=schema, signature=signature, definition=definition)
+        self.on_entity = coerce_to_unquoted(on_entity)
+
+    def render_self_for_migration(self, omit_definition=False) -> str:
+        """Render a string that is valid python code to reconstruct self in a migration"""
+        var_name = self.to_variable_name()
+        class_name = self.__class__.__name__
+        escaped_definition = self.definition if not omit_definition else "# not required for op"
+
+        return f"""{var_name} = {class_name}(
+            schema="{self.schema}",
+            signature="{self.signature}",
+            on_entity="{self.on_entity}",
+            definition={repr(escaped_definition)}
+        )\n\n"""

--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -1,6 +1,3 @@
-# pylint: disable=unused-argument,invalid-name,line-too-long
-from __future__ import annotations
-
 from typing import List
 
 from parse import parse
@@ -24,7 +21,7 @@ class PGPolicy(OnEntityMixin, ReplaceableEntity):
     """
 
     @classmethod
-    def from_sql(cls, sql: str) -> PGPolicy:
+    def from_sql(cls, sql: str) -> "PGPolicy":
         """Create an instance instance from a SQL string"""
 
         template = "create policy{:s}{signature}{:s}on{:s}{on_entity}{:s}{definition}"
@@ -66,7 +63,7 @@ class PGPolicy(OnEntityMixin, ReplaceableEntity):
         )
 
     @classmethod
-    def from_database(cls, connection, schema) -> List[PGPolicy]:
+    def from_database(cls, connection, schema) -> List["PGPolicy"]:
         """Get a list of all policies defined in the db"""
         sql = sql_text(
             f"""

--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -1,0 +1,122 @@
+# pylint: disable=unused-argument,invalid-name,line-too-long
+from __future__ import annotations
+
+from typing import List
+
+from parse import parse
+from sqlalchemy import text as sql_text
+
+from alembic_utils.exceptions import SQLParseFailure
+from alembic_utils.on_entity_mixin import OnEntityMixin
+from alembic_utils.replaceable_entity import ReplaceableEntity
+from alembic_utils.statement import coerce_to_quoted
+
+
+class PGPolicy(OnEntityMixin, ReplaceableEntity):
+    """A PostgreSQL Policy compatible with `alembic revision --autogenerate`
+
+    **Parameters:**
+
+    * **schema** - *str*: A SQL schema name
+    * **signature** - *str*: A SQL policy name and tablename, separated by "."
+    * **definition** - *str*:  The definition of the policy, incl. permissive, for, to, using, with check
+    * **on_entity** - *str*:  fully qualifed entity that the policy applies
+    """
+
+    @classmethod
+    def from_sql(cls, sql: str) -> PGPolicy:
+        """Create an instance instance from a SQL string"""
+
+        template = "create policy{:s}{signature}{:s}on{:s}{on_entity}{:s}{definition}"
+        result = parse(template, sql.strip(), case_sensitive=False)
+
+        if result is not None:
+
+            on_entity = result["on_entity"]
+            if "." not in on_entity:
+                schema = "public"
+                on_entity = schema + "." + on_entity
+            schema, _, _ = on_entity.partition(".")
+
+            return cls(
+                schema=schema,
+                signature=result["signature"],
+                definition=result["definition"],
+                on_entity=on_entity,
+            )
+        raise SQLParseFailure(f'Failed to parse SQL into PGPolicy """{sql}"""')
+
+    def to_sql_statement_create(self) -> str:
+        """ Generates a SQL "create poicy" statement for PGPolicy """
+
+        return sql_text(f"CREATE POLICY {self.signature} on {self.on_entity} {self.definition}")
+
+    def to_sql_statement_drop(self) -> str:
+        """Generates a SQL "drop policy" statement for PGPolicy"""
+
+        return sql_text(f"DROP POLICY {self.signature} on {self.on_entity}")
+
+    def to_sql_statement_create_or_replace(self) -> str:
+        """Not implemented, postgres policies do not support replace."""
+        return sql_text(
+            f"""
+            DROP POLICY IF EXISTS {self.signature} on {self.on_entity};
+            CREATE POLICY {self.signature} on {self.on_entity} {self.definition};
+        """
+        )
+
+    @classmethod
+    def from_database(cls, connection, schema) -> List[PGPolicy]:
+        """Get a list of all policies defined in the db"""
+        sql = sql_text(
+            f"""
+        select
+            schemaname,
+            tablename,
+            policyname,
+            permissive,
+            roles,
+            cmd,
+            qual,
+            with_check
+        from
+            pg_policies
+        where
+            schemaname = '{schema}'
+        """
+        )
+        rows = connection.execute(sql).fetchall()
+
+        def get_definition(permissive, roles, cmd, qual, with_check):
+            definition = ""
+            if permissive is not None:
+                definition += f"as {permissive} "
+            if cmd is not None:
+                definition += f"for {cmd} "
+            if roles is not None:
+                definition += f"to {', '.join(roles)} "
+            if qual is not None:
+                if qual[0] != "(":
+                    qual = f"({qual})"
+                definition += f"using {qual} "
+            if with_check is not None:
+                if with_check[0] != "(":
+                    with_check = f"({with_check})"
+                definition += f"with check {with_check} "
+            return definition
+
+        db_policies = []
+        for schema, table, policy_name, permissive, roles, cmd, qual, with_check in rows:
+            definition = get_definition(permissive, roles, cmd, qual, with_check)
+
+            schema = coerce_to_quoted(schema)
+            table = coerce_to_quoted(table)
+            policy_name = coerce_to_quoted(policy_name)
+            sql = f"create policy {policy_name} on {schema}.{table} {definition}"
+            policy = PGPolicy.from_sql(sql)
+            db_policies.append(policy)
+
+        for policy in db_policies:
+            assert policy is not None
+
+        return db_policies

--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -175,10 +175,10 @@ class ReplaceableEntity:
         escaped_definition = self.definition if not omit_definition else "# not required for op"
 
         return f"""{var_name} = {class_name}(
-            schema="{self.schema}",
-            signature="{self.signature}",
-            definition={repr(escaped_definition)}
-        )\n\n"""
+    schema="{self.schema}",
+    signature="{self.signature}",
+    definition={repr(escaped_definition)}
+)\n\n"""
 
     @classmethod
     def render_import_statement(cls) -> str:

--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -19,6 +19,7 @@ from alembic_utils.exceptions import (
 )
 from alembic_utils.reversible_op import ReversibleOp
 from alembic_utils.statement import (
+    coerce_to_unquoted,
     escape_colon,
     normalize_whitespace,
     strip_terminating_semicolon,
@@ -102,11 +103,9 @@ def solve_resolution_order(sess: Session, entities):
 class ReplaceableEntity:
     """A SQL Entity that can be replaced"""
 
-    _CACHE = {}
-
     def __init__(self, schema: str, signature: str, definition: str):
-        self.schema: str = normalize_whitespace(schema)
-        self.signature: str = normalize_whitespace(signature)
+        self.schema: str = coerce_to_unquoted(normalize_whitespace(schema))
+        self.signature: str = coerce_to_unquoted(normalize_whitespace(signature))
         self.definition: str = escape_colon(strip_terminating_semicolon(definition))
 
     @classmethod

--- a/src/alembic_utils/statement.py
+++ b/src/alembic_utils/statement.py
@@ -24,3 +24,35 @@ def escape_colon(sql: str) -> str:
     sql = sql.replace(":", "\:")
     sql = sql.replace(holder, "::")
     return sql
+
+
+def coerce_to_quoted(text: str) -> str:
+    """Coerces schema and entity names to double quoted one
+
+    Examples:
+        coerce_to_quoted('"public"') => '"public"'
+        coerce_to_quoted('public') => '"public"'
+        coerce_to_quoted('public.table') => '"public"."table"'
+        coerce_to_quoted('"public".table') => '"public"."table"'
+        coerce_to_quoted('public."table"') => '"public"."table"'
+    """
+    if "." in text:
+        schema, _, name = text.partition(".")
+        schema = f'"{strip_double_quotes(schema)}"'
+        name = f'"{strip_double_quotes(name)}"'
+        return f"{schema}.{name}"
+
+    text = strip_double_quotes(text)
+    return f'"{text}"'
+
+
+def coerce_to_unquoted(text: str) -> str:
+    """Coerces schema and entity names to unquoted
+
+    Examples:
+        coerce_to_unquoted('"public"') => 'public'
+        coerce_to_unquoted('public') => 'public'
+        coerce_to_unquoted('public.table') => 'public.table'
+        coerce_to_unquoted('"public".table') => 'public.table'
+    """
+    return "".join(text.split('"'))

--- a/src/test/test_pg_policy.py
+++ b/src/test/test_pg_policy.py
@@ -1,0 +1,192 @@
+from typing import Generator
+
+import pytest
+
+from alembic_utils.exceptions import SQLParseFailure
+from alembic_utils.pg_policy import PGPolicy
+from alembic_utils.replaceable_entity import register_entities
+from alembic_utils.testbase import TEST_VERSIONS_ROOT, run_alembic_command
+
+TEST_POLICY = PGPolicy(
+    schema="public",
+    signature="some_policy",
+    on_entity="public.some_tab",
+    definition="""
+    for all
+    to anon_user
+    using (true)
+    with check (true);
+    """,
+)
+
+
+@pytest.fixture()
+def schema_setup(engine) -> Generator[None, None, None]:
+    engine.execute(
+        """
+    create table public.some_tab (
+        id serial primary key,
+        name text
+    );
+
+    create user anon_user;
+    """
+    )
+    yield
+    engine.execute(
+        """
+    drop table public.some_tab;
+    drop user anon_user;
+    """
+    )
+
+
+def test_unparsable() -> None:
+    sql = "create po mypol on public.sometab for all;"
+    with pytest.raises(SQLParseFailure):
+        PGPolicy.from_sql(sql)
+
+
+def test_parse_without_schema_on_entity() -> None:
+
+    sql = "CREATE POLICY mypol on accOunt as PERMISSIVE for SELECT to account_creator using (true) wiTh CHECK (true)"
+
+    policy = PGPolicy.from_sql(sql)
+    assert policy.schema == "public"
+    assert policy.signature == "mypol"
+    assert policy.on_entity == "public.accOunt"
+    assert (
+        policy.definition
+        == "as PERMISSIVE for SELECT to account_creator using (true) wiTh CHECK (true)"
+    )
+
+
+def test_create_revision(engine, schema_setup) -> None:
+    register_entities([TEST_POLICY])
+
+    output = run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "1", "message": "create"},
+    )
+
+    migration_create_path = TEST_VERSIONS_ROOT / "1_create.py"
+
+    with migration_create_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.create_entity" in migration_contents
+    assert "op.drop_entity" in migration_contents
+    assert "op.replace_entity" not in migration_contents
+    assert "from alembic_utils.pg_policy import PGPolicy" in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+def test_update_revision(engine, schema_setup) -> None:
+    # Create the view outside of a revision
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    # Update definition of TO_UPPER
+    UPDATED_TEST_POLICY = PGPolicy(
+        schema=TEST_POLICY.schema,
+        signature=TEST_POLICY.signature,
+        on_entity=TEST_POLICY.on_entity,
+        definition="""
+        for update
+        to anon_user
+        using (true);
+        """,
+    )
+
+    register_entities([UPDATED_TEST_POLICY])
+
+    # Autogenerate a new migration
+    # It should detect the change we made and produce a "replace_function" statement
+    output = run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "2", "message": "replace"},
+    )
+
+    migration_replace_path = TEST_VERSIONS_ROOT / "2_replace.py"
+
+    with migration_replace_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.replace_entity" in migration_contents
+    assert "op.create_entity" not in migration_contents
+    assert "op.drop_entity" not in migration_contents
+    assert "from alembic_utils.pg_policy import PGPolicy" in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+def test_noop_revision(engine, schema_setup) -> None:
+    # Create the view outside of a revision
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    register_entities([TEST_POLICY])
+
+    # Create a third migration without making changes.
+    # This should result in no create, drop or replace statements
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+
+    output = run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "3", "message": "do_nothing"},
+    )
+    migration_do_nothing_path = TEST_VERSIONS_ROOT / "3_do_nothing.py"
+
+    with migration_do_nothing_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.create_entity" not in migration_contents
+    assert "op.drop_entity" not in migration_contents
+    assert "op.replace_entity" not in migration_contents
+    assert "from alembic_utils" not in migration_contents
+    assert "from alembic_utils.pg_policy import PGPolicy" not in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
+
+
+def test_drop_revision(engine, schema_setup) -> None:
+
+    # Register no functions locally
+    register_entities([], schemas=["public"])
+
+    # Manually create a SQL function
+    engine.execute(TEST_POLICY.to_sql_statement_create())
+
+    output = run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "1", "message": "drop"},
+    )
+
+    migration_create_path = TEST_VERSIONS_ROOT / "1_drop.py"
+
+    with migration_create_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    # import pdb; pdb.set_trace()
+
+    assert "op.drop_entity" in migration_contents
+    assert "op.create_entity" in migration_contents
+    assert "from alembic_utils" in migration_contents
+    assert migration_contents.index("op.drop_entity") < migration_contents.index("op.create_entity")
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})

--- a/src/test/test_statement.py
+++ b/src/test/test_statement.py
@@ -1,0 +1,16 @@
+from alembic_utils.statement import coerce_to_quoted, coerce_to_unquoted
+
+
+def test_coerce_to_quoted() -> None:
+    assert coerce_to_quoted('"public"') == '"public"'
+    assert coerce_to_quoted("public") == '"public"'
+    assert coerce_to_quoted("public.table") == '"public"."table"'
+    assert coerce_to_quoted('"public".table') == '"public"."table"'
+    assert coerce_to_quoted('public."table"') == '"public"."table"'
+
+
+def test_coerce_to_unquoted() -> None:
+    assert coerce_to_unquoted('"public"') == "public"
+    assert coerce_to_unquoted("public") == "public"
+    assert coerce_to_unquoted("public.table") == "public.table"
+    assert coerce_to_unquoted('"public".table') == "public.table"


### PR DESCRIPTION
Create a new entity mixin for entities that rely on another entity for provide their schema (like triggers and policies)

Implement PGPolicy

Reduce likelihood of variable name collision