### PR TITLE
Use standard include functions from AutogenContext

### DIFF
--- a/src/alembic_utils/pg_function.py
+++ b/src/alembic_utils/pg_function.py
@@ -26,6 +26,8 @@ class PGFunction(ReplaceableEntity):
     * **definition** - *str*:  The remainig function body and identifiers
     """
 
+    type_ = "function"
+
     def __init__(self, schema: str, signature: str, definition: str):
         super().__init__(schema, signature, definition)
         # Detect if function uses plpgsql and update escaping rules to not escape ":="

--- a/src/alembic_utils/pg_grant_table.py
+++ b/src/alembic_utils/pg_grant_table.py
@@ -65,6 +65,8 @@ class PGGrantTable(ReplaceableEntity):
     grant: Grant
     with_grant_option: bool
 
+    type_ = "grant_table"
+
     def __init__(
         self,
         schema: str,
@@ -80,6 +82,7 @@ class PGGrantTable(ReplaceableEntity):
         self.role: str = coerce_to_unquoted(role)
         self.grant: Grant = Grant(grant)
         self.with_grant_option: bool = with_grant_option
+        self.signature = f"{self.schema}.{self.table}.{self.role}.{self.grant}"
 
     @classmethod
     def from_sql(cls, sql: str) -> "PGGrantTable":

--- a/src/alembic_utils/pg_materialized_view.py
+++ b/src/alembic_utils/pg_materialized_view.py
@@ -24,6 +24,8 @@ class PGMaterializedView(ReplaceableEntity):
     * **with_data** - *bool*: Should create and replace statements populate data
     """
 
+    type_ = "materialized_view"
+
     def __init__(self, schema: str, signature: str, definition: str, with_data: bool = True):
         super().__init__(schema=schema, signature=signature, definition=definition)
         self.with_data = with_data

--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -18,6 +18,8 @@ class PGPolicy(OnEntityMixin, ReplaceableEntity):
     * **on_entity** - *str*:  fully qualifed entity that the policy applies
     """
 
+    type_ = "policy"
+
     @classmethod
     def from_sql(cls, sql: str) -> "PGPolicy":
         """Create an instance instance from a SQL string"""

--- a/src/alembic_utils/pg_trigger.py
+++ b/src/alembic_utils/pg_trigger.py
@@ -30,6 +30,8 @@ class PGTrigger(OnEntityMixin, ReplaceableEntity):
         EXECUTE PROCEDURE function_name ( arguments )
     """
 
+    type_ = "trigger"
+
     _templates = [
         "create{:s}constraint{:s}trigger{:s}{signature}{:s}{event}{:s}ON{:s}{on_entity}{:s}{action}",
         "create{:s}trigger{:s}{signature}{:s}{event}{:s}ON{:s}{on_entity}{:s}{action}",

--- a/src/alembic_utils/pg_view.py
+++ b/src/alembic_utils/pg_view.py
@@ -20,6 +20,8 @@ class PGView(ReplaceableEntity):
     * **definition** - *str*: The SQL select statement body of the view
     """
 
+    type_ = "view"
+
     @classmethod
     def from_sql(cls, sql: str) -> "PGView":
         """Create an instance from a SQL string"""

--- a/src/test/test_include_filters.py
+++ b/src/test/test_include_filters.py
@@ -1,0 +1,108 @@
+from alembic_utils.pg_view import PGView
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.replaceable_entity import register_entities
+from alembic_utils.testbase import TEST_VERSIONS_ROOT, run_alembic_command
+
+
+# The objects marked as "excluded" have names corresponding
+# to the filters in src/test/alembic_config/env.py
+
+IncludedView = PGView(
+    schema="public",
+    signature="A_view",
+    definition="select 1 as one",
+)
+
+ObjExcludedView = PGView(
+    schema="public",
+    signature="exclude_obj_view",
+    definition="select 1 as one",
+)
+
+ReflectedIncludedView = PGView(
+    schema="public",
+    signature="reflected_view",
+    definition="select 1 as one",
+)
+
+ReflectedExcludedView = PGView(
+    schema="public",
+    signature="exclude_name_reflected_view",
+    definition="select 1 as one",
+)
+
+
+FuncDef = """
+        returns text
+        as
+        $$ begin return upper(some_text) || 'abc'; end; $$ language PLPGSQL;
+        """
+
+IncludedFunc = PGFunction(
+    schema="public", signature="toUpper(some_text text default 'my text!')", definition=FuncDef
+)
+
+ObjExcludedFunc = PGFunction(
+    schema="public",
+    signature="exclude_obj_toUpper(some_text text default 'my text!')",
+    definition=FuncDef,
+)
+
+ReflectedIncludedFunc = PGFunction(
+    schema="public",
+    signature="reflected_toUpper(some_text text default 'my text!')",
+    definition=FuncDef,
+)
+
+ReflectedExcludedFunc = PGFunction(
+    schema="public",
+    signature="exclude_obj_reflected_toUpper(some_text text default 'my text!')",
+    definition=FuncDef,
+)
+
+reflected_entities = [
+    ReflectedIncludedView,
+    ReflectedExcludedView,
+    ReflectedIncludedFunc,
+    ReflectedExcludedFunc,
+]
+
+registered_entities = [
+    IncludedView,
+    ObjExcludedView,
+    IncludedFunc,
+    ObjExcludedFunc,
+]
+
+
+def test_create_revision_with_filters(engine) -> None:
+    for entity in reflected_entities:
+        engine.execute(entity.to_sql_statement_create())
+    register_entities(registered_entities)
+
+    run_alembic_command(
+        engine=engine,
+        command="revision",
+        command_kwargs={"autogenerate": True, "rev_id": "1", "message": "filtered_upgrade"},
+    )
+
+    migration_create_path = TEST_VERSIONS_ROOT / "1_filtered_upgrade.py"
+
+    with migration_create_path.open() as migration_file:
+        migration_contents = migration_file.read()
+
+    assert "op.create_entity(public_a_view)" in migration_contents
+    assert "op.create_entity(public_toupper)" in migration_contents
+    assert "op.drop_entity(public_reflected_view)" in migration_contents
+    assert "op.drop_entity(public_reflected_toupper)" in migration_contents
+
+    assert not "op.create_entity(public_exclude_obj_view)" in migration_contents
+    assert not "op.create_entity(public_exclude_obj_toupper)" in migration_contents
+    assert not "op.drop_entity(public_exclude_name_reflected_view)" in migration_contents
+    assert not "op.drop_entity(public_exclude_obj_reflected_toupper)" in migration_contents
+
+    # Execute upgrade
+    run_alembic_command(engine=engine, command="upgrade", command_kwargs={"revision": "head"})
+    # Execute Downgrade
+    run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})


### PR DESCRIPTION
According to https://alembic.sqlalchemy.org/en/latest/api/autogenerate.html#alembic.autogenerate.api.AutogenContext.run_name_filters
 `run_name_filters` and `run_object_filters` should be called during auto-generation operations. This PR introduces calls to these functions.

The impact of not having these function calls is that users cannot affect the behaviour of the auto generation using `include_object` and `include_name` in `env.py`.

This issue manifested itself in our case since we use multiple environments in one `alembic.ini` file as described here https://alembic.sqlalchemy.org/en/latest/cookbook.html#multiple-environments we do this to manage different schemas separately within one DB.

The call to `compare_registered_entities` gets a list of all schemas in the database (`sqla_schemas`) and therefore reflects all entities (e.g. all views) across all schemas. This leads to all entities in schemas other than the one we're trying to manage in a given environment being considered as candidates to be dropped.

We see a similar problem with tables in the default behaviour of Alembic but we can use `include_object` to solve this along the lines of https://github.com/sqlalchemy/alembic/issues/710#issuecomment-657230887

With this PR, we can use the same approach to handle entities from `alembic_utils`.