### PR TITLE
Fix "reference before assignment" error when logging ignored entities

### DIFF
--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -334,9 +334,9 @@ def register_entities(
 
                         if not include_entity(db_entity, autogen_context, reflected=True):
                             logger.debug(
-                                "Ignoring local entity %s %s due to AutogenContext filters",
-                                entity.__class__.__name__,
-                                entity.identity,
+                                "Ignoring remote entity %s %s due to AutogenContext filters",
+                                db_entity.__class__.__name__,
+                                db_entity.identity,
                             )
                             continue
 


### PR DESCRIPTION
This only causes an error when the earlier `for entity in ordered_entities:` does not create a variable named `entity` (i.e. when there are not yet any replaceable entities in the project). However even in the case where it doesn't throw an error, it will log erroneous information (because it is referencing `entity` rather than `db_entity` which is the object being considered).