### PR TITLE
Do not retry statement without drop, when drop was succesful

### DIFF
--- a/src/alembic_utils/simulate.py
+++ b/src/alembic_utils/simulate.py
@@ -42,17 +42,18 @@ def simulate_entity(
             for mgr in dependency_managers:
                 stack.enter_context(mgr)
 
-            did_yield = False
+            did_drop = False
             try:
                 sess.begin_nested()
                 sess.execute(entity.to_sql_statement_drop(cascade=True))
+                did_drop = True
                 sess.execute(entity.to_sql_statement_create())
-                did_yield = True
                 yield sess
             except:
-                if did_yield:
-                    # the error came from user code after the yield
-                    # so we can exit
+                if did_drop:
+                    # The drop was successful, so either create was not, or the
+                    # error came from user code after the yield.
+                    # Anyway, we can exit now.
                     raise
 
                 # Try again without the drop in case the drop raised


### PR DESCRIPTION
This should fix #65. The following code after `except` tries to rerun the create statement in case drop statement failed because the entity did not exist. This PR adds a check if the drop was actually successful, which means the error probably came from syntax error in the user-supplied definition. This is able to fix the issue in #65 for me in the sense I am getting a syntax error instead of 'already exists' error now.

https://github.com/olirice/alembic_utils/blob/f6370b05f76eaf27f8e08e714e297b6f793baaa6/src/alembic_utils/simulate.py#L46-L65