### PR TITLE
Add exclude_modules option for _collect_instances

### DIFF
--- a/src/test/test_collect_instances.py
+++ b/src/test/test_collect_instances.py
@@ -2,6 +2,7 @@ from typing import TypeVar
 
 import flupy
 from flupy import fluent
+from flupy.cli import cli
 
 import alembic_utils
 from alembic_utils.experimental._collect_instances import (
@@ -15,6 +16,13 @@ def test_walk_modules() -> None:
 
     all_modules = [x for x in walk_modules(flupy)]
     assert fluent in all_modules
+
+
+def test_walk_modules_exclude() -> None:
+
+    all_modules = [x for x in walk_modules(flupy, exclude_modules=["flupy.fluent"])]
+    assert fluent not in all_modules
+    assert cli in all_modules
 
 
 def test_collect_instances() -> None:


### PR DESCRIPTION
This PR adds the ability to exclude specified import paths from calls to `collect_instances`, `collect_subclasses` or `walk_modules`. This might be desirable if some module (or its submodules) contain imports of libraries you only have installed in a dev configuration, or if you have large/slow modules to walk.