### PR TITLE
Optimize solve_resolution_order a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IntelliJ IDEA / PyCharm
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.940
     hooks:
     - id: mypy
       files: src/


### PR DESCRIPTION
== DETAILS
This doesn't change the strategy very much, but a couple optimizations:

- don't resolve entities with dependencies if there are none
- in each resolution loop, only iterate over entities that didn't resolve in the previous loop

I had difficulty running the tests. Anything that invoked alembic gets a `KeyError: 'formatter'` error, which seems to indicate it's not loading `alembic.ini` correctly, but I'm
not sure how to solve that.

However, I did do a basic smoke test with my own sqlalchemy/alembic/alembic_utils project.