### PR TITLE
Improve logging

### DIFF
--- a/src/alembic_utils/depends.py
+++ b/src/alembic_utils/depends.py
@@ -30,8 +30,8 @@ def solve_resolution_order(sess: Session, entities):
             continue
 
     # Resolve entities with possible dependencies
+    logger.info("Resolving entities with dependencies. This may take a minute")
     for _ in range(len(entities)):
-        logger.info("Resolving entities with dependencies. This may take a minute")
         n_resolved = len(resolved)
 
         for entity in entities:


### PR DESCRIPTION
== DETAILS
Move the `Resolving entities with dependencies` log statement outside
the loop so it doesn't repeat with each resolution pass.