### PR TITLE
Fix docstring for replaceable_entity.register_entities

### DIFF
--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -246,7 +246,7 @@ def register_entities(
 
     * **schemas** - *Optional[List[str]]*: A list of SQL schema names to monitor. Note, schemas referenced in registered entities are automatically monitored.
     * **exclude_schemas** - *Optional[List[str]]*: A list of SQL schemas to ignore. Note, explicitly registered entities will still be monitored.
-    * **entity_types** - *Optional[List[str]]*: A list of ReplaceableEntity classes to consider during migrations. Other entity types are ignored
+    * **entity_types** - *Optional[List[Type[ReplaceableEntity]]]*: A list of ReplaceableEntity classes to consider during migrations. Other entity types are ignored
     """
     registry.register(entities, schemas, exclude_schemas, entity_types)
 


### PR DESCRIPTION
**Motivation**:
I was trying to include a postgres view in the alembic context. When using `alembic_utils.replaceable_entity.register_entities` I realised that actually the description for the `entity_types` argument is not accurate: instead of `List[str]` should be `List[Type[ReplaceableEntity]] `. 

Example of usage: https://github.com/olirice/alembic_utils/blob/master/src/test/test_depends.py#:~:text=entity_types%3D%5B-,PGView,-%5D)

**Changes**:
- Update the docstring for `register_entities`