### PR TITLE
Remove extras requirement for sqlalchemy-stubs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ DEV_REQUIRES = [
     "pylint",
     "pre-commit",
     "mypy",
-    "sqlalchemy-stubs",
     "psycopg2-binary",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
SqlAlchemy 1.4 uses sqlalchemy2-stubs as the package it ships stubs in -- alembic_utils requiring the legacy sqlalchemy-stubs package causes issues with mypy plugin integration. I'm submitting a PR to remove the requirement rather than upgrade because it seems like convention is to let the consumer decide which to install. Happy to swap the package to sqlalchemy2-stubs instead, though.

Let me know if this makes sense! Appreciate all the work you've put in to this project.