### PR TITLE
Test sqlalchemy 1.4 and 2.0 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+            python-version: ['3.8', '3.9', '3.10', '3.11']
             postgres-version: ['11', '12', '13', '14', '15']
+            sqlalchemy-version: ['1.4', '2.0']
 
     services:
 
@@ -35,6 +36,7 @@ jobs:
         pip install --upgrade pip
         pip install wheel
         pip install -e ".[dev]"
+        pip install ${{ matrix.sqlalchemy-version }}
 
     - name: Test with Coverage
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         pip install --upgrade pip
         pip install wheel
         pip install -e ".[dev]"
-        pip install ${{ matrix.sqlalchemy-version }}
+        pip install "sqlalchemy==${{ matrix.sqlalchemy-version }}"
 
     - name: Test with Coverage
       run: |

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Incompatible but not fully understood behavior found between 1.4 and 2.0. Adding 1.4 to CI to avoid regressions

ref #110 