### PR TITLE
More robust function parsing with pglast, procedure support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(
         "alembic>=1.9",
         "flupy",
         "parse>=1.8.4",
+        "pglast>=6.2",
         "sqlalchemy>=1.4",
+        "psycopg2-binary>=2.9.3",
         "typing_extensions",
     ],
     extras_require={

--- a/src/alembic_utils/statement.py
+++ b/src/alembic_utils/statement.py
@@ -1,4 +1,168 @@
+import logging
 from uuid import uuid4
+
+import pglast
+import pglast.ast
+from pglast.stream import RawStream, IndentedStream
+from parse import parse
+
+from alembic_utils.exceptions import SQLParseFailure
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_func_signature_returns_and_type(func_sql: str):
+    """
+    return the function signature, returns clause, and whether it is a procedure
+    """
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("raw sql: %s", func_sql)
+        parse_tree_json = pglast.parser.parse_sql_json(func_sql)
+        logger.debug("parse_tree_json: %s", parse_tree_json)
+
+    parse_tree = pglast.parser.parse_sql(func_sql)
+    if len(parse_tree) != 1:
+        raise ValueError(f"Expected 1 statement, got {len(parse_tree)}")
+
+    stmt = parse_tree[0].stmt
+
+    if not isinstance(stmt, pglast.ast.CreateFunctionStmt):
+        raise ValueError(f"Expected CreateFunctionStmt got {stmt}")
+
+    is_proc = stmt.is_procedure
+
+    stmt.is_procedure = False
+    stmt.replace = False
+    stmt.options = []
+    stmt.sql_body = None
+
+    if len(stmt.funcname) > 1:
+        # Remove schema name
+        stmt.funcname = stmt.funcname[1:]
+
+    stmt_str = RawStream()(parse_tree[0])
+
+    prefix = "create function"
+    if not stmt_str.lower().startswith(prefix):
+        raise ValueError(f"Expected {prefix} got {stmt_str}")
+
+    stmt_str = stmt_str[len(prefix) :].strip()
+    return stmt_str, is_proc
+
+
+def _get_func_schema(func_sql: str, default="public") -> str:
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("raw sql: %s", func_sql)
+        parse_tree_json = pglast.parser.parse_sql_json(func_sql)
+        logger.debug("parse_tree_json: %s", parse_tree_json)
+
+    parse_tree = pglast.parser.parse_sql(func_sql)
+    if len(parse_tree) != 1:
+        raise ValueError(f"Expected 1 statement, got {len(parse_tree)}")
+
+    stmt = parse_tree[0].stmt
+
+    if not isinstance(stmt, pglast.ast.CreateFunctionStmt):
+        raise ValueError(f"Expected CreateFunctionStmt got {stmt}")
+
+    if len(stmt.funcname) > 1:
+        schema_name = RawStream()(stmt.funcname[0])
+        if schema_name.startswith('"') or schema_name.startswith("'"):
+            schema_name = schema_name[1:-1]
+        return schema_name
+    return default
+
+
+def _get_func_body(func_sql: str) -> str:
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("raw sql: %s", func_sql)
+        parse_tree_json = pglast.parser.parse_sql_json(func_sql)
+        logger.debug("parse_tree_json: %s", parse_tree_json)
+
+    dummy_func_sql = "CREATE FUNCTION foo.bar() RETURNS void AS $$ BEGIN $$ LANGUAGE plpgsql;"
+    parse_tree_dummy = pglast.parser.parse_sql(dummy_func_sql)
+
+    parse_tree = pglast.parser.parse_sql(func_sql)
+    if len(parse_tree) != 1:
+        raise ValueError(f"Expected 1 statement, got {len(parse_tree)}")
+
+    stmt = parse_tree[0].stmt
+
+    if not isinstance(stmt, pglast.ast.CreateFunctionStmt):
+        raise ValueError(f"Expected CreateFunctionStmt got {stmt}")
+
+    stmt.replace = False
+    stmt.is_procedure = False
+    stmt.funcname = parse_tree_dummy[0].stmt.funcname
+    stmt.parameters = parse_tree_dummy[0].stmt.parameters
+    stmt.returnType = parse_tree_dummy[0].stmt.returnType
+
+    func_str = IndentedStream(comma_at_eoln=True)(parse_tree)
+    func_split = func_str.split("RETURNS void")
+    if len(func_split) != 2:
+        raise ValueError(f"Expected 1 instance of RETURNS void in statement: {func_sql}")
+    if func_split[0].strip().lower() != "create function foo.bar()":
+        raise ValueError(f"Expected CREATE FUNCTION foo.bar() got {func_split[0]}")
+    return func_split[1]
+
+
+def validate_split_function(signature, returns, schema, body, is_proc):
+    entity_kind = "PROCEDURE" if is_proc else "FUNCTION"
+    reconstructed_sql = f"CREATE {entity_kind} {schema}.{signature} {returns} {body}"
+    pglast.parser.parse_sql(reconstructed_sql)
+
+
+def split_function(sql: str):
+    """
+    split a function or procedure into: signature, returns clause, schema, body, and whether it is a procedure
+    """
+    try:
+        signature_and_return, is_proc = _get_func_signature_returns_and_type(sql)
+        template = "{signature}returns{ret_type}"
+        result = parse(template, signature_and_return, case_sensitive=False)
+        if result is None:
+            raw_signature = signature_and_return
+            returns = ""
+        else:
+            raw_signature = result["signature"].strip()
+            returns = f"returns {result['ret_type'].strip()}"
+
+        schema = _get_func_schema(sql)
+        body = _get_func_body(sql)
+
+        # remove possible quotes from signature
+        signature = "".join(raw_signature.split('"', 2)) if raw_signature.startswith('"') else raw_signature
+
+        validate_split_function(signature, returns, schema, body, is_proc)
+        return signature, returns, schema, body, is_proc
+    except pglast.parser.ParseError as e:
+        raise SQLParseFailure(str(e)) from e
+
+
+def render_drop_statement(func_sql: str, is_proc: bool) -> str:
+    entity_kind = "PROCEDURE" if is_proc else "FUNCTION"
+
+    dummy_drop_sql = f"DROP {entity_kind} sqrt(integer);"
+    parse_tree = pglast.parser.parse_sql(dummy_drop_sql)
+    assert len(parse_tree) == 1
+    stmt = parse_tree[0].stmt
+    assert isinstance(stmt, pglast.ast.DropStmt)
+    assert len(stmt.objects) == 1
+    obj = stmt.objects[0]
+
+    parse_tree2 = pglast.parser.parse_sql(func_sql)
+    assert len(parse_tree2) == 1
+    stmt2 = parse_tree2[0].stmt
+    assert isinstance(stmt2, pglast.ast.CreateFunctionStmt)
+
+    obj.objname = stmt2.funcname
+    obj.objargs = []
+    obj.objfuncargs = stmt2.parameters
+    for arg in obj.objfuncargs or []:
+        arg.defexpr = None
+
+    return RawStream()(parse_tree)
 
 
 def normalize_whitespace(text, base_whitespace: str = " ") -> str:

--- a/src/test/test_pg_function.py
+++ b/src/test/test_pg_function.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass
+import logging
+
+import pytest
 from sqlalchemy import text
 
 from alembic_utils.pg_function import PGFunction
@@ -14,9 +18,65 @@ TO_UPPER = PGFunction(
         """,
 )
 
+TO_UPPER_UPDATED_DEF = r'''returns text as
+    $$
+    select upper(some_text) || 'def'  -- """ \n \\
+    $$ language SQL immutable strict;'''
 
-def test_create_revision(engine) -> None:
-    register_entities([TO_UPPER], entity_types=[PGFunction])
+
+CLEAR_CACHE = PGFunction(
+    schema="public",
+    signature="clear_cache(obj_id uuid)",
+    definition="""
+LANGUAGE plpgsql
+AS $procedure$
+DECLARE
+BEGIN
+    CALL clear_parent_obj(obj_id, true);
+END;
+$procedure$
+""",
+    is_proc=True,
+)
+
+CLEAR_CACHE_UPDATED_DEF = """
+AS $procedure$
+DECLARE
+BEGIN
+    CALL clear_parent_obj(obj_id, true);
+    CALL clear_child_obj(obj_id, true);
+END;
+$procedure$ language plpgsql
+"""
+
+
+@dataclass
+class FuncMigrationTestCase:
+    name: str
+    func: PGFunction
+    updated_def: str
+
+
+_TEST_CASES = [
+    FuncMigrationTestCase(
+        name="toUpper",
+        func=TO_UPPER,
+        updated_def=TO_UPPER_UPDATED_DEF,
+    ),
+    FuncMigrationTestCase(
+        name="clear_cache",
+        func=CLEAR_CACHE,
+        updated_def=CLEAR_CACHE_UPDATED_DEF,
+    ),
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("data", _TEST_CASES, ids=[tc.name for tc in _TEST_CASES])
+def test_create_revision(engine, data) -> None:
+    register_entities([data.func], entity_types=[PGFunction])
 
     run_alembic_command(
         engine=engine,
@@ -40,21 +100,20 @@ def test_create_revision(engine) -> None:
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
 
-def test_update_revision(engine) -> None:
+@pytest.mark.parametrize("data", _TEST_CASES, ids=[tc.name for tc in _TEST_CASES])
+def test_update_revision(engine, data) -> None:
     with engine.begin() as connection:
-        connection.execute(TO_UPPER.to_sql_statement_create())
+        connection.execute(data.func.to_sql_statement_create())
 
-    # Update definition of TO_UPPER
-    UPDATED_TO_UPPER = PGFunction(
-        TO_UPPER.schema,
-        TO_UPPER.signature,
-        r'''returns text as
-    $$
-    select upper(some_text) || 'def'  -- """ \n \\
-    $$ language SQL immutable strict;''',
+    # Update definition
+    updated_func = PGFunction(
+        schema= data.func.schema,
+        signature=data.func.signature,
+        definition=data.updated_def,
+        is_proc=data.func.is_proc,
     )
 
-    register_entities([UPDATED_TO_UPPER], entity_types=[PGFunction])
+    register_entities([updated_func], entity_types=[PGFunction])
 
     # Autogenerate a new migration
     # It should detect the change we made and produce a "replace_function" statement
@@ -81,11 +140,12 @@ def test_update_revision(engine) -> None:
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
 
-def test_noop_revision(engine) -> None:
+@pytest.mark.parametrize("data", _TEST_CASES, ids=[tc.name for tc in _TEST_CASES])
+def test_noop_revision(engine, data) -> None:
     with engine.begin() as connection:
-        connection.execute(TO_UPPER.to_sql_statement_create())
+        connection.execute(data.func.to_sql_statement_create())
 
-    register_entities([TO_UPPER], entity_types=[PGFunction])
+    register_entities([data.func], entity_types=[PGFunction])
 
     output = run_alembic_command(
         engine=engine,
@@ -108,10 +168,11 @@ def test_noop_revision(engine) -> None:
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
 
-def test_drop(engine) -> None:
+@pytest.mark.parametrize("data", _TEST_CASES, ids=[tc.name for tc in _TEST_CASES])
+def test_drop(engine, data) -> None:
     # Manually create a SQL function
     with engine.begin() as connection:
-        connection.execute(TO_UPPER.to_sql_statement_create())
+        connection.execute(data.func.to_sql_statement_create())
 
     # Register no functions locally
     register_entities([], schemas=["public"], entity_types=[PGFunction])
@@ -199,7 +260,7 @@ def test_ignores_extension_functions(engine) -> None:
             connection.execute(text("drop extension if exists unaccent;"))
 
 
-def test_plpgsql_colon_esacpe(engine) -> None:
+def test_plpgsql_colon_escape(engine) -> None:
     # PGFunction.__init__ overrides colon escapes for plpgsql
     # because := should not be escaped for sqlalchemy.text
     # if := is escaped, an exception would be raised

--- a/src/test/test_statement.py
+++ b/src/test/test_statement.py
@@ -1,4 +1,111 @@
-from alembic_utils.statement import coerce_to_quoted, coerce_to_unquoted
+from dataclasses import dataclass
+import pytest
+
+from alembic_utils.statement import (
+    coerce_to_quoted,
+    coerce_to_unquoted,
+    split_function,
+    render_drop_statement,
+    normalize_whitespace,
+)
+
+
+@dataclass
+class FuncTestCase:
+    name: str
+    sql: str
+    expected_signature: str
+    expected_returns: str
+    expected_schema: str
+    expected_body: str
+    expected_is_proc: bool
+    expected_drop_stmt: str
+    allow_error: bool
+
+
+_TEST_CASES = [
+    FuncTestCase(
+        name="internal function",
+        sql="""
+CREATE FUNCTION square_root(double precision) RETURNS double precision
+AS 'dsqrt' LANGUAGE internal STRICT;
+""",
+        expected_signature="square_root(double precision)",
+        expected_returns="returns double precision",
+        expected_schema="public",
+        # note: STRICT is the same as RETURNS NULL ON NULL INPUT. Is there a way to preserve the original keyword?
+        expected_body="AS $$dsqrt$$ LANGUAGE internal RETURNS NULL ON NULL INPUT",
+        expected_is_proc=False,
+        expected_drop_stmt="DROP FUNCTION square_root (double precision)",
+        allow_error=False,
+    ),
+    FuncTestCase(
+        name="function with default, OUT paramter, and no RETURNS",
+        sql="""
+CREATE OR REPLACE FUNCTION func_w_default(in_fields text[] = ARRAY['foo', 'bar'], OUT data jsonb)
+language 'plpgsql' as $func$ SELECT 1; $func$
+""",
+        expected_signature="func_w_default(in_fields text[] = ARRAY['foo', 'bar'], OUT data jsonb)",
+        expected_returns="",
+        expected_schema="public",
+        expected_body="LANGUAGE plpgsql AS $$ SELECT 1; $$",
+        expected_is_proc=False,
+        expected_drop_stmt="DROP FUNCTION func_w_default (in_fields text[], OUT data jsonb)",
+        allow_error=False,
+    ),
+    FuncTestCase(
+        name="procedure",
+        sql="""
+CREATE OR REPLACE PROCEDURE myschema.clear_cache(obj_id uuid)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+BEGIN
+    CALL clear_parent(obj_id, true);
+END;
+$$
+""",
+        expected_signature="clear_cache(obj_id uuid)",
+        expected_returns="",
+        expected_schema="myschema",
+        expected_body="LANGUAGE plpgsql AS $$ DECLARE BEGIN CALL clear_parent(obj_id, true); END; $$",
+        expected_is_proc=True,
+        expected_drop_stmt="DROP PROCEDURE myschema.clear_cache (obj_id uuid)",
+        allow_error=False,
+    ),
+    FuncTestCase(
+        name="begin atomic",
+        sql="""
+CREATE OR REPLACE FUNCTION select_int(n integer)
+  RETURNS integer
+  LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+BEGIN ATOMIC
+    RETURN n;
+END
+""",
+        expected_signature="select_int(n integer)",
+        expected_returns="returns integer",
+        expected_schema="public",
+        expected_body="LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE BEGIN ATOMIC RETURN n; END",
+        expected_is_proc=False,
+        expected_drop_stmt="",
+        allow_error=True,  # BEGIN ATOMIC not yet supported by pglast
+    ),
+]
+
+
+@pytest.mark.parametrize("data", _TEST_CASES, ids=[tc.name for tc in _TEST_CASES])
+def test_split_function(data: FuncTestCase) -> None:
+    if data.allow_error:
+        pytest.xfail("This test is expected to fail")
+
+    signature, returns, schema, body, is_proc = split_function(data.sql)
+    assert is_proc == data.expected_is_proc
+    assert render_drop_statement(data.sql, is_proc) == data.expected_drop_stmt
+    assert signature == data.expected_signature
+    assert returns == data.expected_returns
+    assert schema == data.expected_schema
+    assert normalize_whitespace(body) == data.expected_body
 
 
 def test_coerce_to_quoted() -> None:


### PR DESCRIPTION
- Use pglast to parse functions into signature and definition
- Add support for procedures

Caveats:
- pglast parsing was only added for functions/procedures, not any other kind of entity
- functions formatting and comments are not preserved
- SQL constructs with equivalent representations may be transformed. e.g. `STRICT` may be changed to `RETURNS NULL ON NULL INPUT`