### PR TITLE
Fix quotes for "on_entity" in generated sql for PGFunction and PGTrigger

### DIFF
--- a/src/alembic_utils/pg_policy.py
+++ b/src/alembic_utils/pg_policy.py
@@ -46,17 +46,17 @@ class PGPolicy(OnEntityMixin, ReplaceableEntity):
     def to_sql_statement_create(self):
         """Generates a SQL "create poicy" statement for PGPolicy"""
 
-        return sql_text(f"CREATE POLICY {self.signature} on {self.on_entity} {self.definition}")
+        return sql_text(f'CREATE POLICY "{self.signature}" on {coerce_to_quoted(self.on_entity)} {self.definition}')
 
     def to_sql_statement_drop(self, cascade=False):
         """Generates a SQL "drop policy" statement for PGPolicy"""
         cascade = "cascade" if cascade else ""
-        return sql_text(f"DROP POLICY {self.signature} on {self.on_entity} {cascade}")
+        return sql_text(f'DROP POLICY "{self.signature}" on {coerce_to_quoted(self.on_entity)} {cascade}')
 
     def to_sql_statement_create_or_replace(self):
         """Not implemented, postgres policies do not support replace."""
-        yield sql_text(f"DROP POLICY IF EXISTS {self.signature} on {self.on_entity};")
-        yield sql_text(f"CREATE POLICY {self.signature} on {self.on_entity} {self.definition};")
+        yield sql_text(f'DROP POLICY IF EXISTS "{self.signature}" on {coerce_to_quoted(self.on_entity)};')
+        yield sql_text(f'CREATE POLICY "{self.signature}" on {coerce_to_quoted(self.on_entity)} {self.definition};')
 
     @classmethod
     def from_database(cls, connection, schema):

--- a/src/alembic_utils/pg_trigger.py
+++ b/src/alembic_utils/pg_trigger.py
@@ -6,6 +6,7 @@ from sqlalchemy import text as sql_text
 from alembic_utils.exceptions import SQLParseFailure
 from alembic_utils.on_entity_mixin import OnEntityMixin
 from alembic_utils.replaceable_entity import ReplaceableEntity
+from alembic_utils.statement import coerce_to_quoted
 
 
 class PGTrigger(OnEntityMixin, ReplaceableEntity):
@@ -133,11 +134,11 @@ class PGTrigger(OnEntityMixin, ReplaceableEntity):
     def to_sql_statement_drop(self, cascade=False):
         """Generates a SQL "drop trigger" statement for PGTrigger"""
         cascade = "cascade" if cascade else ""
-        return sql_text(f'DROP TRIGGER "{self.signature}" ON {self.on_entity} {cascade}')
+        return sql_text(f'DROP TRIGGER "{self.signature}" ON {coerce_to_quoted(self.on_entity)} {cascade}')
 
     def to_sql_statement_create_or_replace(self):
         """Generates a SQL "replace trigger" statement for PGTrigger"""
-        yield sql_text(f'DROP TRIGGER IF EXISTS "{self.signature}" ON {self.on_entity};')
+        yield sql_text(f'DROP TRIGGER IF EXISTS "{self.signature}" ON {coerce_to_quoted(self.on_entity)};')
         yield self.to_sql_statement_create()
 
     @classmethod


### PR DESCRIPTION
The generated create and drop statements didn't quote the `on_entity` schema/tablename. So `alembic upgrade` errored on statements like
```
DROP TRIGGER "modified" ON test.MyCamelCaseTable
```

This patch fixes this.

It seems correct for the other entities.