### PR TITLE
Bugfix - check `exclude_schemas` check in `compare_registered_entities`

### DIFF
--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -281,7 +281,7 @@ def compare_registered_entities(
         if (
             schema_name
             is not None
-            not in (
+            and schema_name not in (
                 registry.exclude_schemas or set()
             )  # user defined. Deprecated for remove in 0.6.0
             and schema_name not in {"information_schema", None}


### PR DESCRIPTION
# Context

Previously, the check for `excluded_schemas` in `compare_registered_entities` was not working, because of this line:

```py
observed_schemas: Set[str] = {
    schema_name
    for schema_name in all_schema_references
    if (
        schema_name
        is not None
        # OFFENDING LINE BELOW
        not in (
            registry.exclude_schemas or set()
        )  # user defined. Deprecated for remove in 0.6.0
        and schema_name not in {"information_schema", None}
    )
}
```

This evaluated `schema_name is not None` to a bool, and then checked `<bool> not in (registry.exclude_schemas or set())` which is ~always false.