### PR TITLE
Add explicit setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description_file = README.md
+license_files = LICENSE


### PR DESCRIPTION
Various setuptools versions create a `setup.cfg`, and it's seemingly being synthesized with a property called `description-file`. This string format is deprecated and it should be `description_file`. This PR adds an explicit `setup.cfg` with the proper string format.