### PR TITLE
Support granting select on tables and to public

### DIFF
--- a/src/alembic_utils/pg_grant_table.py
+++ b/src/alembic_utils/pg_grant_table.py
@@ -13,7 +13,7 @@ from alembic_utils.statement import coerce_to_quoted, coerce_to_unquoted
 
 
 class PGGrantTableChoice(str, Enum):
-    # Applies at column level
+    # Applies at either table or column level
     SELECT = "SELECT"
     INSERT = "INSERT"
     UPDATE = "UPDATE"
@@ -56,7 +56,7 @@ class PGGrantTable(ReplaceableEntity):
 
     * **schema** - *str*: A SQL schema name
     * **table** - *str*: The table to grant access to
-    * **columns** - *List[str]*: A list of column names on *table* to grant access to
+    * **columns** - *List[str]*: A list of column names on *table* to grant access to. If empty or None, the grant applies to the whole table.
     * **role** - *str*: The role to grant access to
     * **grant** - *Union[Grant, str]*: On of SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
     * **with_grant_option** - *bool*: Can the role grant access to other roles
@@ -88,12 +88,7 @@ class PGGrantTable(ReplaceableEntity):
         self.with_grant_option: bool = with_grant_option
         self.signature = self.identity
 
-        if PGGrantTableChoice(self.grant) in {C.SELECT, C.INSERT, C.UPDATE, C.REFERENCES}:
-            if len(self.columns) == 0:
-                raise BadInputException(
-                    f"When grant type is {self.grant} a value must be provided for columns"
-                )
-        else:
+        if PGGrantTableChoice(self.grant) not in {C.SELECT, C.INSERT, C.UPDATE, C.REFERENCES}:
             if self.columns:
                 raise BadInputException(
                     f"When grant type is {self.grant} a value must not be provided for columns"
@@ -109,6 +104,9 @@ class PGGrantTable(ReplaceableEntity):
         # rows in information_schema.role_column_grants are uniquely identified by
         # the columns listed below + the grantor
         # be cautious when editing
+        # This is used to detect conflicting entities. Multiple `PGGrantTable` to the same table and role
+        # conflict with each other because of how Postgres handles grants and revokes.  Indeed,
+        # `PGGrantTable.to_sql_statement_drop` drops all grants for the table and role.
         return f"{self.__class__.__name__}: {self.schema}.{self.table}.{self.role}.{self.grant}"
 
     @property
@@ -131,6 +129,40 @@ class PGGrantTable(ReplaceableEntity):
 
     @classmethod
     def from_database(cls, sess: Session, schema: str = "%"):
+        grants = []
+        # TABLE LEVEL
+        sql = sql_text(
+            """
+        SELECT
+            table_schema as schema_name,
+            table_name,
+            grantee as role_name,
+            privilege_type as grant_option,
+            is_grantable
+        FROM
+            information_schema.role_table_grants rcg
+        WHERE
+            grantor = CURRENT_USER
+            and grantor != grantee
+            and table_schema like :schema
+            and privilege_type in ('SELECT', 'INSERT', 'UPDATE', 'REFERENCES', 'DELETE', 'TRUNCATE', 'TRIGGER')
+        """
+        )
+
+        rows_table = sess.execute(sql, params={"schema": schema}).fetchall()
+        table_level_grants = set()
+
+        for schema_name, table_name, role_name, grant_option, is_grantable in rows_table:
+            grant = cls(
+                schema=schema_name,
+                table=table_name,
+                role=role_name,
+                grant=grant_option,
+                with_grant_option=is_grantable == "YES",
+            )
+            grants.append(grant)
+            table_level_grants.add((table_name, role_name, grant_option, is_grantable))
+
         # COLUMN LEVEL
         sql = sql_text(
             """
@@ -143,27 +175,26 @@ class PGGrantTable(ReplaceableEntity):
             column_name
         FROM
             information_schema.role_column_grants rcg
-            -- Cant revoke from superusers so filter out those recs
-            join pg_roles pr
-                on rcg.grantee = pr.rolname
         WHERE
-            not pr.rolsuper
-            and grantor = CURRENT_USER
+            grantor = CURRENT_USER
+            and grantor != grantee
             and table_schema like :schema
             and privilege_type in ('SELECT', 'INSERT', 'UPDATE', 'REFERENCES')
         """
         )
 
-        rows = sess.execute(sql, params={"schema": schema}).fetchall()
-        grants = []
+        rows_column = sess.execute(sql, params={"schema": schema}).fetchall()
 
         grouped = (
-            flu(rows)
+            flu(rows_column)
             .group_by(lambda x: SchemaTableRole(*x[:5]))
             .map(lambda x: (x[0], x[1].map_item(5).collect()))
             .collect()
         )
         for s_t_r, columns in grouped:
+            if (s_t_r.table, s_t_r.role, s_t_r.grant, s_t_r.with_grant_option) in table_level_grants:
+                # Skip the table level grants
+                continue
             grant = cls(
                 schema=s_t_r.schema,
                 table=s_t_r.table,
@@ -171,40 +202,6 @@ class PGGrantTable(ReplaceableEntity):
                 grant=s_t_r.grant,
                 with_grant_option=s_t_r.with_grant_option == "YES",
                 columns=columns,
-            )
-            grants.append(grant)
-
-        # TABLE LEVEL
-        sql = sql_text(
-            """
-        SELECT
-            table_schema as schema_name,
-            table_name,
-            grantee as role_name,
-            privilege_type as grant_option,
-            is_grantable
-        FROM
-            information_schema.role_table_grants rcg
-            -- Cant revoke from superusers so filter out those recs
-            join pg_roles pr
-                on rcg.grantee = pr.rolname
-        WHERE
-            not pr.rolsuper
-            and grantor = CURRENT_USER
-            and table_schema like :schema
-            and privilege_type in ('DELETE', 'TRUNCATE', 'TRIGGER')
-        """
-        )
-
-        rows = sess.execute(sql, params={"schema": schema}).fetchall()
-
-        for schema_name, table_name, role_name, grant_option, is_grantable in rows:
-            grant = cls(
-                schema=schema_name,
-                table=table_name,
-                role=role_name,
-                grant=grant_option,
-                with_grant_option=is_grantable == "YES",
             )
             grants.append(grant)
         return grants

--- a/src/alembic_utils/pg_grant_table.py
+++ b/src/alembic_utils/pg_grant_table.py
@@ -149,10 +149,10 @@ class PGGrantTable(ReplaceableEntity):
         """
         )
 
-        rows_table = sess.execute(sql, params={"schema": schema}).fetchall()
+        rows = sess.execute(sql, params={"schema": schema}).fetchall()
         table_level_grants = set()
 
-        for schema_name, table_name, role_name, grant_option, is_grantable in rows_table:
+        for schema_name, table_name, role_name, grant_option, is_grantable in rows:
             grant = cls(
                 schema=schema_name,
                 table=table_name,
@@ -183,10 +183,10 @@ class PGGrantTable(ReplaceableEntity):
         """
         )
 
-        rows_column = sess.execute(sql, params={"schema": schema}).fetchall()
+        rows = sess.execute(sql, params={"schema": schema}).fetchall()
 
         grouped = (
-            flu(rows_column)
+            flu(rows)
             .group_by(lambda x: SchemaTableRole(*x[:5]))
             .map(lambda x: (x[0], x[1].map_item(5).collect()))
             .collect()

--- a/src/alembic_utils/pg_grant_table.py
+++ b/src/alembic_utils/pg_grant_table.py
@@ -57,7 +57,7 @@ class PGGrantTable(ReplaceableEntity):
     * **schema** - *str*: A SQL schema name
     * **table** - *str*: The table to grant access to
     * **columns** - *List[str]*: A list of column names on *table* to grant access to. If empty or None, the grant applies to the whole table.
-    * **role** - *str*: The role to grant access to
+    * **role** - *str*: The role to grant access to. To grant access to all roles, use "PUBLIC".
     * **grant** - *Union[Grant, str]*: On of SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
     * **with_grant_option** - *bool*: Can the role grant access to other roles
     """
@@ -210,15 +210,17 @@ class PGGrantTable(ReplaceableEntity):
         """Generates a SQL "create view" statement"""
         with_grant_option = " WITH GRANT OPTION" if self.with_grant_option else ""
         maybe_columns_clause = f'( {", ".join(self.columns)} )' if self.columns else ""
+        role_or_public = coerce_to_quoted(self.role) if self.role != "PUBLIC" else "PUBLIC"
         return sql_text(
-            f"GRANT {self.grant} {maybe_columns_clause} ON {self.literal_schema}.{coerce_to_quoted(self.table)} TO {coerce_to_quoted(self.role)} {with_grant_option}"
+            f"GRANT {self.grant} {maybe_columns_clause} ON {self.literal_schema}.{coerce_to_quoted(self.table)} TO {role_or_public} {with_grant_option}"
         )
 
     def to_sql_statement_drop(self, cascade=False) -> TextClause:
         """Generates a SQL "drop view" statement"""
         # cascade has no impact
+        role_or_public = coerce_to_quoted(self.role) if self.role != "PUBLIC" else "PUBLIC"
         return sql_text(
-            f"REVOKE {self.grant} ON {self.literal_schema}.{coerce_to_quoted(self.table)} FROM {coerce_to_quoted(self.role)}"
+            f"REVOKE {self.grant} ON {self.literal_schema}.{coerce_to_quoted(self.table)} FROM {role_or_public}"
         )
 
     def to_sql_statement_create_or_replace(self) -> Generator[TextClause, None, None]:

--- a/src/alembic_utils/replaceable_entity.py
+++ b/src/alembic_utils/replaceable_entity.py
@@ -20,7 +20,7 @@ from sqlalchemy.sql.elements import TextClause
 
 import alembic_utils
 from alembic_utils.depends import solve_resolution_order
-from alembic_utils.exceptions import UnreachableException
+from alembic_utils.exceptions import BadInputException, UnreachableException
 from alembic_utils.experimental import collect_subclasses
 from alembic_utils.reversible_op import (
     CreateOp,
@@ -198,7 +198,16 @@ class ReplaceableEntityRegistry:
         exclude_schemas: Optional[Iterable[str]] = None,
         entity_types: Optional[Iterable[Type[ReplaceableEntity]]] = None,
     ) -> None:
-        self._entities.update({e.identity: e for e in entities})
+        for entity in entities:
+            if entity.identity in self._entities:
+                if str(self._entities[entity.identity].to_sql_statement_create()) != str(entity.to_sql_statement_create()):
+                    # If the two entities generates the same SQL, it is not a conflict and we can overwrite it.
+                    raise BadInputException(
+                        f"Entity with identity {entity.identity} already registered. \n"
+                        f"Existing entity: {self._entities[entity.identity]} \n"
+                        f"New entity: {entity}"
+                    )
+            self._entities[entity.identity] = entity
 
         if schemas:
             self.schemas |= set(schemas)

--- a/src/test/test_duplicate_registration.py
+++ b/src/test/test_duplicate_registration.py
@@ -1,4 +1,8 @@
+import pytest
+
+from alembic_utils.exceptions import BadInputException
 from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_grant_table import PGGrantTable, PGGrantTableChoice
 from alembic_utils.replaceable_entity import register_entities, registry
 from alembic_utils.testbase import run_alembic_command
 
@@ -29,3 +33,24 @@ def test_migration_create_function(engine) -> None:
         command="revision",
         command_kwargs={"autogenerate": True, "rev_id": "1", "message": "raise"},
     )
+
+def test_table_grant_to_table_and_column_raises(engine) -> None:
+    table_grant = PGGrantTable(
+        schema="public",
+        table="account",
+        role="anon_user",
+        grant=PGGrantTableChoice.SELECT,
+        with_grant_option=False,
+    )
+
+    column_grant = PGGrantTable(
+        schema="public",
+        table="account",
+        columns=["id", "email"],
+        role="anon_user",
+        grant=PGGrantTableChoice.SELECT,
+        with_grant_option=False,
+    )
+
+    with pytest.raises(BadInputException):
+        register_entities([table_grant, column_grant], entity_types=[PGGrantTable])

--- a/src/test/test_pg_grant_table.py
+++ b/src/test/test_pg_grant_table.py
@@ -76,8 +76,8 @@ def test_create_revision(sql_setup, engine, role) -> None:
     with migration_create_path.open() as migration_file:
         migration_contents = migration_file.read()
 
-    assert "op.create_entity" in migration_contents
-    assert "op.drop_entity" in migration_contents
+    assert migration_contents.count("op.create_entity") == 1
+    assert migration_contents.count("op.drop_entity") == 1
     assert "op.replace_entity" not in migration_contents
     assert "from alembic_utils.pg_grant_table import PGGrantTable" in migration_contents
 
@@ -105,7 +105,7 @@ def test_replace_revision(sql_setup, engine, role) -> None:
         migration_contents = migration_file.read()
 
     # Granting can not be done in place.
-    assert "op.replace_entity" in migration_contents
+    assert migration_contents.count("op.replace_entity") == 2
     assert "op.create_entity" not in migration_contents
     assert "op.drop_entity" not in migration_contents
     assert "from alembic_utils.pg_grant_table import PGGrantTable" in migration_contents
@@ -173,6 +173,7 @@ def test_drop_revision(sql_setup, engine, role) -> None:
 
     assert migration_contents.count("op.drop_entity") == 1
     assert migration_contents.count("op.create_entity") == 1
+    assert "from alembic_utils" in migration_contents
     assert migration_contents.index("op.drop_entity") < migration_contents.index("op.create_entity")
 
     # Execute upgrade

--- a/src/test/test_pg_grant_table.py
+++ b/src/test/test_pg_grant_table.py
@@ -31,7 +31,7 @@ TEST_GRANT = PGGrantTable(
     schema="public",
     table="account",
     role="anon_user",
-    grant=PGGrantTableChoice.DELETE,
+    grant=PGGrantTableChoice.SELECT,
     with_grant_option=False,
 )
 
@@ -50,15 +50,6 @@ def test_bad_input():
             role="anon_user",
             grant=PGGrantTableChoice.DELETE,
             columns=["id"],  # columns not allowed for delete
-        )
-
-    with pytest.raises(BadInputException):
-        PGGrantTable(
-            schema="public",
-            table="account",
-            role="anon_user",
-            grant=PGGrantTableChoice.SELECT,
-            # columns required for select
         )
 
 
@@ -94,7 +85,7 @@ def test_replace_revision(sql_setup, engine) -> None:
         schema="public",
         table="account",
         role="anon_user",
-        grant=PGGrantTableChoice.DELETE,
+        grant=PGGrantTableChoice.SELECT,
         with_grant_option=True,
     )
 
@@ -176,9 +167,8 @@ def test_drop_revision(sql_setup, engine) -> None:
 
     # import pdb; pdb.set_trace()
 
-    assert "op.drop_entity" in migration_contents
-    assert "op.create_entity" in migration_contents
-    assert "from alembic_utils" in migration_contents
+    assert migration_contents.count("op.drop_entity") == 1
+    assert migration_contents.count("op.create_entity") == 1
     assert migration_contents.index("op.drop_entity") < migration_contents.index("op.create_entity")
 
     # Execute upgrade

--- a/src/test/test_pg_grant_table.py
+++ b/src/test/test_pg_grant_table.py
@@ -27,13 +27,23 @@ def sql_setup(engine):
         connection.execute(text("drop table public.account cascade"))
 
 
-TEST_GRANT = PGGrantTable(
-    schema="public",
-    table="account",
-    role="anon_user",
-    grant=PGGrantTableChoice.SELECT,
-    with_grant_option=False,
-)
+def _pg_grant_table(
+    schema: str = "public",
+    table: str = "account",
+    role: str = "anon_user",
+    grant: PGGrantTableChoice = PGGrantTableChoice.SELECT,
+    columns: list[str] | None = None,
+    with_grant_option: bool = False,
+) -> PGGrantTable:
+    """Helper function to create a PGGrantTable object with defaults."""
+    return PGGrantTable(
+        schema=schema,
+        table=table,
+        role=role,
+        grant=grant,
+        columns=columns,
+        with_grant_option=with_grant_option,
+    )
 
 
 def test_repr():
@@ -52,9 +62,9 @@ def test_bad_input():
             columns=["id"],  # columns not allowed for delete
         )
 
-
-def test_create_revision(sql_setup, engine) -> None:
-    register_entities([TEST_GRANT], entity_types=[PGGrantTable])
+@pytest.mark.parametrize("role", ["anon_user", "PUBLIC"])
+def test_create_revision(sql_setup, engine, role) -> None:
+    register_entities([_pg_grant_table(role=role)], entity_types=[PGGrantTable])
     run_alembic_command(
         engine=engine,
         command="revision",
@@ -77,19 +87,12 @@ def test_create_revision(sql_setup, engine) -> None:
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
 
-def test_replace_revision(sql_setup, engine) -> None:
+@pytest.mark.parametrize("role", ["anon_user", "PUBLIC"])
+def test_replace_revision(sql_setup, engine, role) -> None:
     with engine.begin() as connection:
-        connection.execute(TEST_GRANT.to_sql_statement_create())
+        connection.execute(_pg_grant_table(role=role).to_sql_statement_create())
 
-    UPDATED_GRANT = PGGrantTable(
-        schema="public",
-        table="account",
-        role="anon_user",
-        grant=PGGrantTableChoice.SELECT,
-        with_grant_option=True,
-    )
-
-    register_entities([UPDATED_GRANT], entity_types=[PGGrantTable])
+    register_entities([_pg_grant_table(role=role, columns=["id"])], entity_types=[PGGrantTable])
     run_alembic_command(
         engine=engine,
         command="revision",
@@ -112,13 +115,14 @@ def test_replace_revision(sql_setup, engine) -> None:
     # Execute Downgrade
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
-
-def test_noop_revision(sql_setup, engine) -> None:
+@pytest.mark.parametrize("role", ["anon_user", "PUBLIC"])
+def test_create_revision_with_grant_option(sql_setup, engine, role) -> None:
+    test_grant = _pg_grant_table(role=role)
     # Create the view outside of a revision
     with engine.begin() as connection:
-        connection.execute(TEST_GRANT.to_sql_statement_create())
+        connection.execute(test_grant.to_sql_statement_create())
 
-    register_entities([TEST_GRANT], entity_types=[PGGrantTable])
+    register_entities([test_grant], entity_types=[PGGrantTable])
 
     # Create a third migration without making changes.
     # This should result in no create, drop or replace statements
@@ -144,15 +148,15 @@ def test_noop_revision(sql_setup, engine) -> None:
     # Execute Downgrade
     run_alembic_command(engine=engine, command="downgrade", command_kwargs={"revision": "base"})
 
-
-def test_drop_revision(sql_setup, engine) -> None:
+@pytest.mark.parametrize("role", ["anon_user", "PUBLIC"])
+def test_drop_revision(sql_setup, engine, role) -> None:
 
     # Register no functions locally
     register_entities([], schemas=["public"], entity_types=[PGGrantTable])
 
     # Manually create a SQL function
     with engine.begin() as connection:
-        connection.execute(TEST_GRANT.to_sql_statement_create())
+        connection.execute(_pg_grant_table(role=role).to_sql_statement_create())
 
     output = run_alembic_command(
         engine=engine,


### PR DESCRIPTION
To support granting select/insert/update/references to tables,
1. Excludes column-level grants from what `from_database` returns. This is necessary to prevent creating two drop_entity.
2. To catch the above, tests are updated to check the count of ops, instead of just checking inclusion.
3. Table-level grant and column-level grant share the same `PGGrantTable.identity`. The users shouldn't register both. Add a check and a test.

To support granting privileges to public,
1. Avoid (inner-)joining `pg_roles`. Instead, `grantor != grantee` was added to exclude the privileges granted because the current_user is a superuser, or the privileges granted because the tables are owned by the current_user.
2. Do not apply `coerce_to_quoted` for `PUBLIC`.
3. Parametrize tests to cover role (`anon_user`) and public.